### PR TITLE
Update advanced usage example with workspace_access and project_access attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ The `examples/basic_usage` directory contains a basic example configuration for 
 
 ### Advanced Usage
 
-The `examples/advanced_usage` directory contains an advanced example configuration for using the module. It provides an example of managing team access to TFE projects and workspaces.
+The `examples/advanced_usage` directory contains an advanced example configuration for using the module. It provides an example of managing team access to TFE projects and workspaces, including the `workspace_access` and `project_access` attributes.

--- a/examples/advanced_usage/main.tf
+++ b/examples/advanced_usage/main.tf
@@ -7,7 +7,46 @@ module "tfe_team" {
 
   team_name      = var.team_name
   organization   = var.organization
-  tfe_projects   = var.tfe_projects
+  tfe_projects   = [
+    {
+      name = "project1"
+      access_level = "read"
+      project_access = {
+        settings = "read"
+        teams    = "none"
+      }
+      workspace_access = {
+        state_versions = "none"
+        sentinel_mocks = "none"
+        runs           = "read"
+        variables      = "none"
+        create         = false
+        locking        = false
+        move           = false
+        delete         = false
+        run_tasks      = false
+      }
+    },
+    {
+      name = "project2"
+      access_level = "write"
+      project_access = {
+        settings = "write"
+        teams    = "read"
+      }
+      workspace_access = {
+        state_versions = "read"
+        sentinel_mocks = "read"
+        runs           = "write"
+        variables      = "read"
+        create         = true
+        locking        = true
+        move           = true
+        delete         = true
+        run_tasks      = true
+      }
+    }
+  ]
   tfe_workspaces = var.tfe_workspaces
 }
 

--- a/examples/advanced_usage/variables.tf
+++ b/examples/advanced_usage/variables.tf
@@ -13,6 +13,21 @@ variable "tfe_projects" {
   type = list(object({
     name         = string
     access_level = string
+    project_access = optional(object({
+      settings = optional(string, "read")
+      teams    = optional(string, "none")
+    }), null)
+    workspace_access = optional(object({
+      state_versions = optional(string, "none")
+      sentinel_mocks = optional(string, "none")
+      runs           = optional(string, "read")
+      variables      = optional(string, "none")
+      create         = optional(bool, false)
+      locking        = optional(bool, false)
+      move           = optional(bool, false)
+      delete         = optional(bool, false)
+      run_tasks      = optional(bool, false)
+    }), null)
   }))
   default = []
 }


### PR DESCRIPTION
Add `workspace_access` and `project_access` attributes to `tfe_projects` variable in advanced usage example.

* Update `examples/advanced_usage/variables.tf` to include `workspace_access` and `project_access` attributes in the `tfe_projects` variable.
* Update `examples/advanced_usage/main.tf` to reference `workspace_access` and `project_access` attributes for the `tfe_projects` variable and expand the `tfe_projects` variable to show these attributes.
* Update `README.md` to mention `workspace_access` and `project_access` attributes in the advanced usage example.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HappyPathway/terraform-tfe-team/pull/2?shareId=4b6779f6-c2d9-4e46-83e3-f12db2f7dfd3).